### PR TITLE
Reputation integration

### DIFF
--- a/src/components/Profile/ReputationContent.tsx
+++ b/src/components/Profile/ReputationContent.tsx
@@ -2,6 +2,7 @@ import { Box, Grid, TextField } from "@mui/material";
 import React, { useState, useEffect } from "react";
 import { ERC20Integration } from "./ERC20Integration";
 import { AddressHistory } from "./AddressHistory";
+import { ReputationScoreIntegration } from "./ReputationScoreIntegration";
 import { useWeb3 } from "@/context/web3Context";
 import { Search } from "../Search/Search";
 import { useSearchContext } from "@/hooks/useSearch";
@@ -24,6 +25,11 @@ export const ReputationContent: React.FC = () => {
       <Grid item xs={6} md={4}>
         Address history:
         <AddressHistory address={address} chain={network} />
+      </Grid>
+
+      <Grid item xs={6} md={4}>
+        Reputation score:
+        <ReputationScoreIntegration address={address} chain={network} />
       </Grid>
 
       <Grid item xs={6} md={4}>

--- a/src/components/Profile/ReputationScoreIntegration.tsx
+++ b/src/components/Profile/ReputationScoreIntegration.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { useReputationScore, } from "../../hooks/useReputationScore";
+import { MoralisChainOptions } from "../../hooks/useMoralisChainOptions";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Paper from "@mui/material/Paper";
+
+export interface ReputationScoreIntegrationProps {
+  address: string;
+  chain: MoralisChainOptions;
+}
+
+export const ReputationScoreIntegration: React.FC<ReputationScoreIntegrationProps> = (
+  props: ReputationScoreIntegrationProps
+) => {
+  const assets: number | null | undefined = useReputationScore(
+    props.address,
+    props.chain
+  );
+
+  return (
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: 650 }} aria-label="simple table">
+        <TableHead>
+          <TableRow>
+            <TableCell align="left">Reputation Score</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
+            <TableCell align="left">{assets}</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/src/hooks/useActivity.ts
+++ b/src/hooks/useActivity.ts
@@ -28,7 +28,7 @@ export const useActivity = (
     address: address,
   });
 
-  const {
+  let {
     fetch: getHistory,
     data: history,
     error: error2,
@@ -65,14 +65,17 @@ export const useActivity = (
     const activeBuyerSeller = transactionsPerMonth > 2;
 
     await getHistory({ params: { chain: chain, address: address } });
-    let numAllTransactions = history?.['total'];
-    if (numAllTransactions === undefined) {
-      numAllTransactions = 1;
+    if (history?.['total'] && history?.['page_size'] && history?.['total'] !== 0) {
+      if (history?.['total'] > history?.['page_size']){
+        const offset: number = history?.['total'] - (history?.['total'] % history?.['page_size']);
+        console.log("Total transactions (" + history?.['total'] + ") greater than page size (" + history?.['page_size'] + "). Getting last page using offset of: " + offset);
+        history = await account.getTransactions({chain: chain, address: address, offset: offset});
+        console.log("Getting last page (page " + history?.['page'] + ") of transactions.");
+      }
     }
 
     if (history !== undefined && history?.result !== undefined) {
-      const result = history.result;
-      const firstTransaction = history.result[numAllTransactions - 1];
+      const firstTransaction = history.result[history.result.length - 1];
       if (firstTransaction === undefined) return;
 
       const firstTransactionTimestamp = moment(firstTransaction['block_timestamp']);

--- a/src/hooks/useReputationScore.ts
+++ b/src/hooks/useReputationScore.ts
@@ -1,0 +1,95 @@
+import Moralis from 'moralis/types';
+import { useEffect, useState } from 'react';
+import { useMoralis, useMoralisWeb3Api } from 'react-moralis';
+import { MoralisChainOptions } from './useMoralisChainOptions';
+import moment from 'moment';
+
+
+export const useReputationScore = (address: string, chain: MoralisChainOptions): number | null | undefined => {
+  const { account} = useMoralisWeb3Api();
+  const { isInitialized } = useMoralis();
+
+  const [assets, setAssets] = useState<number | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (isInitialized && address !== '') {
+      getReputationScore().then((reputationScore) => setAssets(reputationScore));
+    }
+  }, [address, chain]);
+
+  // function to get avg txns per month for past six months of history
+  const getAvgTxnsPastSixMonths = async (chain: MoralisChainOptions, address: string): Promise<number> => {
+    // slow down API call rate.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const toDate: string = moment().format();
+    const fromDate: string = moment().subtract(6, 'months').format(); 
+    const pastSixMonthsTxns = await account.getTransactions({chain: chain, address: address, from_date: fromDate, to_date: toDate});
+    
+    // pastSixMonthsTxns?.['total'] is total number of transactions over past 6 months
+    if (pastSixMonthsTxns?.['total'] === undefined) {
+      return 0;
+    }
+    else {
+      return pastSixMonthsTxns?.['total'] / 6;
+    }
+  };
+
+  // function to get age of account in months
+  const getAccountAgeMonths = async (chain: MoralisChainOptions, address: string): Promise<number> => {
+    // slow down API call rate.
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    let allTxns = await account.getTransactions({chain: chain, address: address});
+
+    // return 0 if no txn history on-chain
+    if (allTxns?.['total'] && allTxns?.['page_size'] && allTxns?.['total'] !== 0) {
+      // get last "page" of transactions if transaction history spans multiple pages
+      if (allTxns?.['total'] > allTxns?.['page_size']){
+        const offset: number = allTxns?.['total'] - (allTxns?.['total'] % allTxns?.['page_size']);
+        console.log("Total transactions (" + allTxns?.['total'] + ") greater than page size (" + allTxns?.['page_size'] + "). Getting last page using offset of: " + offset);
+        allTxns = await account.getTransactions({chain: chain, address: address, offset: offset});
+        console.log("Getting last page (page " + allTxns?.['page'] + ") of transactions.");
+      }
+    }
+    else {
+      return 0;
+    }
+
+    // calculate age of address using months since first transaction
+    // return 0 if any required parameters are 0
+    if (allTxns !== undefined && allTxns?.result !== undefined) {
+      const firstTxn = allTxns.result[allTxns.result.length - 1];
+      if (firstTxn === undefined) {
+        return 0;
+      }
+      console.log("Timestamp of first transaction: " + moment(firstTxn['block_timestamp']).toString());  
+      const monthsSinceFirstTxn: number = moment().diff(moment(firstTxn['block_timestamp']), 'months'); // off by 1
+      return monthsSinceFirstTxn;
+    }
+    else {
+      return 0;
+    }
+  };
+    
+
+  const getReputationScore = async (): Promise<number | null> => {
+    // determine age score for this account (50% of score)
+    const monthsSinceFirstTxn: number = await getAccountAgeMonths(chain, address);
+    const ageScore: number = 5 - (1.05**(-monthsSinceFirstTxn))*5;
+    console.log("monthsSinceFirstTxn: " + monthsSinceFirstTxn);
+    console.log("ageScore is: " + ageScore);
+
+    // determine avg number of transactions in last 6 months (50% of score)
+    const avgTxnsSixMonths: number = await getAvgTxnsPastSixMonths(chain, address);
+    const avgTxnsSixMonthsScore: number = 5 - (1.07**(-avgTxnsSixMonths))*5;
+    console.log("avgTxnsSixMonths: " + avgTxnsSixMonths);
+    console.log("avgTxnsSixMonthsScore is: " + avgTxnsSixMonthsScore);
+
+    // calculate reputation score
+    const reputationScore: number = ageScore + avgTxnsSixMonthsScore;
+    console.log("Reputation Score is: " + reputationScore);
+
+    return reputationScore;
+  };
+
+  return assets;
+};


### PR DESCRIPTION
Running into Moralis rate-limiting issues on this one. Think they should be looked at before it gets merged.

Also Reputation Score currently uses pretty much the same underlying metrics as useActivity so we can fold it into that one to save on API calls if need be. I think repeatedly calling the API for price data is currently the main source of the rate limiting though so will take a look at that next. 